### PR TITLE
feat: Allow additional conventional commit types for patch versions

### DIFF
--- a/semver/src/main/kotlin/io/datalbry/plugin/semver/version/VersionCalculator.kt
+++ b/semver/src/main/kotlin/io/datalbry/plugin/semver/version/VersionCalculator.kt
@@ -21,35 +21,46 @@ class VersionCalculator {
     fun calculateNextVersion(commits: List<String>, lastVersion: SemanticVersion?): SemanticVersion {
         lastVersion ?: return SemanticVersion(0, 1,0)
 
-        val anyBreakingChange = commits.any { it.hasBreakingChange() }
+        val anyBreakingChange = commits.any { it.hasMajorChange() }
         if (anyBreakingChange) return lastVersion.copy(major = lastVersion.major + 1, minor = 0, patch = 0)
 
-        val anyFeatureAdd = commits.any { it.hasFeatureChange() }
+        val anyFeatureAdd = commits.any { it.hasMinorChange() }
         if (anyFeatureAdd) return lastVersion.copy(minor = lastVersion.minor + 1, patch = 0)
 
-        val anyBugFix = commits.any { it.hasBugFix() }
+        val anyBugFix = commits.any { it.hasPatchChange() }
         if (anyBugFix) return lastVersion.copy(patch = lastVersion.patch + 1)
 
         return lastVersion
     }
 
-    private fun String.hasBreakingChange(): Boolean {
+    private fun String.hasMajorChange(): Boolean {
         val matchResult = Regex(REGEX_COMMIT_MESSAGE).matchEntire(this)
         return matchResult?.groupValues?.getOrNull(4)?.let { it == "!"} ?: false || this.contains("BREAKING CHANGE")
     }
 
-    private fun String.hasFeatureChange(): Boolean {
+    private fun String.hasMinorChange(): Boolean {
         val matchResult = Regex(REGEX_COMMIT_MESSAGE).matchEntire(this)
         return matchResult?.groupValues?.getOrNull(1)?.let { it == "feat" } ?: false
     }
 
-    private fun String.hasBugFix(): Boolean {
+    private fun String.hasPatchChange(): Boolean {
         val matchResult = Regex(REGEX_COMMIT_MESSAGE).matchEntire(this)
-        return matchResult?.groupValues?.getOrNull(1)?.let { it == "fix" } ?: false
+        return matchResult?.groupValues?.getOrNull(1)?.let { it in patchTypes } ?: false
     }
 
     companion object {
         const val REGEX_COMMIT_MESSAGE = """(\w{0,15})(\(?(.{0,40})\))?(!?):(.\S.*)"""
+
+        private val patchTypes = hashSetOf(
+            "fix",
+            "build",
+            "ci",
+            "docs",
+            "pref",
+            "refactor",
+            "style",
+            "test",
+        )
     }
 
 }

--- a/semver/src/test/kotlin/io/datalbry/plugin/semver/version/VersionCalculatorTest.kt
+++ b/semver/src/test/kotlin/io/datalbry/plugin/semver/version/VersionCalculatorTest.kt
@@ -86,6 +86,19 @@ class VersionCalculatorTest {
     }
 
     @Test
+    fun calculateNextVersion_withAllPatchTypes_raisesPatchForEach() {
+        val lastVersion = SemanticVersion(1, 0, 0)
+        val commitTypes = listOf("fix", "build", "ci", "docs", "pref", "refactor", "style", "test")
+        val finalVersion = commitTypes.fold(lastVersion) { currentVersion, nextCommitType ->
+            val commits = listOf("$nextCommitType: another one")
+            versionCalculator.calculateNextVersion(commits, currentVersion)
+        }
+        assertEquals(finalVersion.major, 1)
+        assertEquals(finalVersion.minor, 0)
+        assertEquals(finalVersion.patch, commitTypes.size)
+    }
+
+    @Test
     fun calculateNextVersion_withExclamationMark_raisesMajor() {
         val commits = listOf(
             "fix(scope_1)!: ugh, i hate bugs"


### PR DESCRIPTION
[Convetional Commits](https://www.conventionalcommits.org/en/v1.0.0/) allows other types than `feat:` and `fix:`. This PR adds the recommended types such as `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, and `test:` which will all result in a patch version raise.